### PR TITLE
Remove old wheel metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,3 @@
-[metadata]
-# This includes the license file in the wheel.
-license_files = LICENSE
-
 [flake8]
 ignore = E203, E266, E501, W503
 max-line-length = 90

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,9 +2,6 @@
 # This includes the license file in the wheel.
 license_files = LICENSE
 
-[bdist_wheel]
-universal = 1
-
 [flake8]
 ignore = E203, E266, E501, W503
 max-line-length = 90


### PR DESCRIPTION
Remove some old metadata for building wheels.

# License

`license_files` now includes any files matching `LICENSE` by default. 

https://wheel.readthedocs.io/en/stable/user_guide.html#including-license-files-in-the-generated-wheel-file

# Universal

Universal wheels are for packages which support both Python 2 and 3, and are named like `sphinx_issues-1.2.0-py2.py3-none-any.whl`.

Python 2 is not supported so universal wheels shouldn't be used. Removing the metadata, we get a wheel like `sphinx_issues-1.2.0-py3-none-any.whl`, which has some extra protection against installing on Python 2.

https://packaging.python.org/guides/distributing-packages-using-setuptools/#universal-wheels