### PR TITLE
Fix PytestDeprecationWarning: @pytest.yield_fixture is deprecated.

### DIFF
--- a/test_sphinx_issues.py
+++ b/test_sphinx_issues.py
@@ -19,7 +19,7 @@ from sphinx_issues import (
 import pytest
 
 
-@pytest.yield_fixture(
+@pytest.fixture(
     params=[
         # Parametrize config
         {"issues_github_path": "marshmallow-code/marshmallow"},


### PR DESCRIPTION
Fixes https://github.com/sloria/sphinx-issues/issues/115.

# Before

```console
$ pytest
=================================================== test session starts ===================================================
platform darwin -- Python 3.10.1, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
rootdir: /private/tmp/sphinx-issues
plugins: respx-0.19.0, xdist-2.5.0, freezegun-0.4.2, hypothesis-6.28.0, flaky-3.7.0, timeout-2.0.1, anyio-3.3.4, forked-1.3.0, cov-3.0.0
collected 22 items

test_sphinx_issues.py ......................                                                                        [100%]

==================================================== warnings summary =====================================================
test_sphinx_issues.py:22
  /private/tmp/sphinx-issues/test_sphinx_issues.py:22: PytestDeprecationWarning: @pytest.yield_fixture is deprecated.
  Use @pytest.fixture instead; they are the same.
    @pytest.yield_fixture(

-- Docs: https://docs.pytest.org/en/stable/warnings.html
============================================== 22 passed, 1 warning in 2.00s ==============================================
```

# After

```console
$ pytest
=================================================== test session starts ===================================================
platform darwin -- Python 3.10.1, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
rootdir: /private/tmp/sphinx-issues
plugins: respx-0.19.0, xdist-2.5.0, freezegun-0.4.2, hypothesis-6.28.0, flaky-3.7.0, timeout-2.0.1, anyio-3.3.4, forked-1.3.0, cov-3.0.0
collected 22 items

test_sphinx_issues.py ......................                                                                        [100%]

=================================================== 22 passed in 1.81s ====================================================
```


