### PR TITLE
Test on GitHub Actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,12 @@
+name: Lint
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - uses: pre-commit/action@v2.0.3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,12 +7,11 @@ env:
 
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.6", "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: Test
+
+on: [push, pull_request, workflow_dispatch]
+
+env:
+  FORCE_COLOR: 1
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: "setup.py"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install -U wheel
+          python -m pip install -U tox
+
+      - name: Tox tests
+        run: |
+          tox -e py


### PR DESCRIPTION
As noted here, Travis CI is no longer running: https://github.com/sloria/sphinx-issues/pull/118#issuecomment-991979247

This PR moves testing to GitHub Actions.

There are two workflows.

One does the linting by running pre-commit.

* Demo: https://github.com/hugovk/sphinx-issues/actions/runs/1570533934

The other runs the tests. This improves upon Travis by testing macOS and Windows in addition to Ubuntu. GHA also gives 20 parallel jobs compared to 5 at Travis.

* Demo: https://github.com/hugovk/sphinx-issues/actions/runs/1570533933

---

I've not deleted the `.travis.yml` file yet because one thing it ~does~ did was deploy on tags. 

This can be achieved via GHA using https://github.com/pypa/gh-action-pypi-publish

I've not included it here, because it will need tokens adding as secrets to this repo. But I could prepare another PR after this if you'd like.
