### PR TITLE
Support linking to CWEs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -116,6 +116,8 @@ Changelog
 
 - Drop support for Python 2.7 and 3.5.
 - Test against Python 3.8 to 3.10.
+- Add ``:cwe:`` role for linking to CVEs on https://cwe.mitre.org.
+  Thanks @hugovk for the PR.
 
 1.2.0 (2018-12-26)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -91,6 +91,12 @@ Use the ``:cve:`` role to link to CVEs on https://cve.mitre.org.
 
     :cve:`CVE-2018-17175` - Addresses possible vulnerability when...
 
+Use the ``:cwe:`` role to link to CWEs on https://cwe.mitre.org.
+
+.. code-block:: rst
+
+    :cwe:`CWE-787` - The software writes data past the end, or...
+
 Credits
 *******
 

--- a/sphinx_issues.py
+++ b/sphinx_issues.py
@@ -62,6 +62,27 @@ def cve_role(name, rawtext, text, lineno, inliner, options=None, content=None):
     return [link], []
 
 
+def cwe_role(name, rawtext, text, lineno, inliner, options=None, content=None):
+    """Sphinx role for linking to a CWE on https://cwe.mitre.org.
+
+    Examples: ::
+
+        :cwe:`CWE-787`
+
+    """
+    options = options or {}
+    content = content or []
+    has_explicit_title, title, target = split_explicit_title(text)
+
+    target = utils.unescape(target).strip()
+    title = utils.unescape(title).strip()
+    number = target[4:]
+    ref = f"https://cwe.mitre.org/data/definitions/{number}.html"
+    text = title if has_explicit_title else target
+    link = nodes.reference(text=text, refuri=ref, **options)
+    return [link], []
+
+
 class IssueRole:
 
     EXTERNAL_REPO_REGEX = re.compile(r"^(\w+)/(.+)([#@])([\w]+)$")

--- a/test_sphinx_issues.py
+++ b/test_sphinx_issues.py
@@ -1,10 +1,6 @@
 from tempfile import mkdtemp
 from shutil import rmtree
-
-try:
-    from unittest.mock import Mock
-except ImportError:
-    from unittest.mock import Mock
+from unittest.mock import Mock
 
 from sphinx.application import Sphinx
 from sphinx_issues import (
@@ -12,6 +8,7 @@ from sphinx_issues import (
     user_role,
     pr_role,
     cve_role,
+    cwe_role,
     commit_role,
     setup as issues_setup,
 )
@@ -83,6 +80,13 @@ def inliner(app):
             "CVE-2018-17175",
             "CVE-2018-17175",
             "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-17175",
+        ),
+        (
+            cwe_role,
+            "cve",
+            "CWE-787",
+            "CWE-787",
+            "https://cwe.mitre.org/data/definitions/787.html",
         ),
         (
             commit_role,


### PR DESCRIPTION
Add support for linking to CWE numbers at https://cwe.mitre.org, such as CWE-787 at https://cwe.mitre.org/data/definitions/787.html with:

```rst
:cwe:`CWE-787`
```
The structure is similar to CVEs.