### PR TITLE
feat: add :ghsa: role for GitHub security advisories

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -124,6 +124,12 @@ The ``:pypi:`` role links to project pages on `PyPI <https://pypi.org>`_.
 
     :pypi:`sphinx-issues` - A Sphinx extension for linking to your project's issue tracker.
 
+The ``:ghsa:`` role links to a GitHub security advisory.
+
+.. code-block:: rst
+
+    Fixed in :ghsa:`ab1c-2def-g34h`.
+
 Important note about :cwe: and :cve: roles
 ******************************************
 
@@ -151,6 +157,12 @@ MIT licensed. See the bundled `LICENSE <https://github.com/sloria/sphinx-issues/
 
 Changelog
 *********
+
+6.1.0 (unreleased)
+------------------
+
+- Add ``:ghsa:`` role for linking to GitHub security advisories
+  (`#128 <https://github.com/sloria/sphinx-issues/issues/128>`_).
 
 6.0.0 (2026-03-13)
 ------------------

--- a/src/sphinx_issues/__init__.py
+++ b/src/sphinx_issues/__init__.py
@@ -274,6 +274,21 @@ commit_role = IssueRole(
     pre_format_text=format_commit_text,
 )
 
+
+def format_ghsa_text(config, ghsa_id):
+    return f"GHSA-{ghsa_id}"
+
+
+"""Sphinx role for linking to a GitHub security advisory. Must have
+`issues_ghsa_uri` or `issues_default_group_project` configured in ``conf.py``.
+Examples: ::
+    :ghsa:`ab1c-2def-g34h`
+"""
+ghsa_role = IssueRole(
+    config_prefix="issues_ghsa",
+    pre_format_text=format_ghsa_text,
+)
+
 """Sphinx role for linking to a user profile. Defaults to linking to
 GitHub profiles, but the profile URIS can be configured via the
 ``issues_user_uri`` config value.
@@ -319,6 +334,15 @@ def setup(app):
     app.add_config_value(
         "issues_commit_prefix", default="@", rebuild="html", types=[str]
     )
+    # Format template for GHSA URI
+    # e.g. 'https://github.com/sloria/marshmallow/security/advisories/GHSA-{ghsa}
+    app.add_config_value(
+        "issues_ghsa_uri",
+        default="https://github.com/{group}/{project}/security/advisories/GHSA-{ghsa}",
+        rebuild="html",
+        types=[str],
+    )
+    app.add_config_value("issues_ghsa_prefix", default="#", rebuild="html", types=[str])
     # There is no seperator config as a format_text function is given
 
     # Default User (Group)/Project eg. 'sloria/marshmallow'
@@ -348,6 +372,7 @@ def setup(app):
     app.add_role("user", user_role)
     app.add_role("commit", commit_role)
     app.add_role("pypi", pypi_role)
+    app.add_role("ghsa", ghsa_role)
     return {
         "version": importlib.metadata.version("sphinx-issues"),
         "parallel_read_safe": True,

--- a/tests/test_sphinx_issues.py
+++ b/tests/test_sphinx_issues.py
@@ -12,6 +12,7 @@ import sphinx.application
 
 from sphinx_issues import (
     commit_role,
+    ghsa_role,
     issue_role,
     pr_role,
     pypi_role,
@@ -166,6 +167,20 @@ def inliner_with_config(app_with_config):
             "slo-ria/web-args@abc123d",
             "https://github.com/slo-ria/web-args/commit/abc123def456",
         ),
+        (
+            ghsa_role,
+            "ghsa",
+            "ab1c-2def-g34h",
+            "#GHSA-ab1c-2def-g34h",
+            "https://github.com/marshmallow-code/marshmallow/security/advisories/GHSA-ab1c-2def-g34h",
+        ),
+        (
+            ghsa_role,
+            "ghsa",
+            "Advisory <ab1c-2def-g34h>",
+            "Advisory",
+            "https://github.com/marshmallow-code/marshmallow/security/advisories/GHSA-ab1c-2def-g34h",
+        ),
     ],
 )
 def test_roles(inliner, role, role_name, text, expected_text, expected_url):
@@ -228,6 +243,8 @@ def app_custom_uri():
         "issues_commit_prefix": "@",
         "issues_user_uri": "https://gitlab.company.com/{user}",
         "issues_user_prefix": "@",
+        "issues_ghsa_uri": "https://gitlab.company.com/{group}/{project}/-/security/advisories/GHSA-{ghsa}",
+        "issues_ghsa_prefix": "#",
     }
     try:
         app.config.init_values()
@@ -311,6 +328,13 @@ def inliner_custom_uri(app_custom_uri):
             "sloria/webargs@abc123def456",
             "sloria/webargs@abc123d",
             "https://gitlab.company.com/sloria/webargs/-/commit/abc123def456",
+        ),
+        (
+            ghsa_role,
+            "ghsa",
+            "ab1c-2def-g34h",
+            "#GHSA-ab1c-2def-g34h",
+            "https://gitlab.company.com/myteam/super_great_project/-/security/advisories/GHSA-ab1c-2def-g34h",
         ),
     ],
 )


### PR DESCRIPTION
Adds a `:ghsa:` role for linking to GitHub security advisories, as proposed in #128 where the maintainer commented "I like this idea. PRs welcome!".

Usage: `:ghsa:`ab1c-2def-g34h`` renders `#GHSA-ab1c-2def-g34h` linking to the advisory page. Configurable via `issues_ghsa_uri` and `issues_ghsa_prefix`, mirroring the existing `:commit:` role pattern.

Closes #128